### PR TITLE
Add server time retrieval and refactor leaderboard functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ mono_crash.*.json
 /addons/*
 !/addons/WebBusPlugin/
 /export/*
+
+.vscode/

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ func getting_leaderboard_info(info):
 
 `name_leaderboard` : **String** type
 
-`info` : **JavaScriptObject** type
+`info` : **Dictionary** type
 
 Get leaderboard player entry:
 ```gdscript
@@ -142,7 +142,7 @@ func getting_leaderboard_player_entry(info):
 
 `name_leaderboard` : **String** type
 
-`info` : **JavaScriptObject** type
+`info` : **Dictionary** type
 
 Get leaderboard entries:
 ```gdscript
@@ -163,11 +163,11 @@ func getting_leaderboard_entries(info):
 
 `quantity_top` : **int** type, optional parameter
 
-`info` : **JavaScriptObject** type
+`info` : **Dictionary** type
 
 Save score in leaderboard:
 ```gdscript
-WebBus.set_yandex_leaderboard(name_leaderboard, score, extra_data)
+WebBus.set_leaderboard_score(name_leaderboard, score, extra_data)
 ```
 
 `name_leaderboard` : **String** type
@@ -189,7 +189,7 @@ WebBus.init_payments(signed)
 Make purchase
 
 ```gdscript
-WebBus.purchase(product_id, developer_payload)
+var success = await WebBus.purchase(product_id, developer_payload)
 ```
 
 `product_id`: **String** type

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 It's a plugin for the Godot engine. Use one plugin for several web platform SDKs.
 
 This version is for Godot 4.x.
-### Contents
+## Contents
 
 - [Supported platforms](#supported-platforms)
 - [Installation](#installation)
@@ -13,7 +13,9 @@ This version is for Godot 4.x.
     - [Ready](#ready)
     - [Other](#other)
   - [Yandex](#yandex)
-	- [Leaderboards](#leaderboards)
+	  - [Leaderboards](#leaderboards)
+    - [Payments](#payments)
+    - [Server time](#server-time)
   - [Crazy Games](#crazy-games)
 	  - [Game](#game-1)
   - [Main Screen Menu](#main-screen-menu)
@@ -208,6 +210,14 @@ Get product list
 ```gdscript
 var product_list = await WebBus.get_catalog()
 ```
+#### Server time
+
+Get server time
+
+```gdscript
+var time:int = WebBus.get_server_time() # Example: 1720613073778
+```
+
 
 ### Crazy Games
 #### Game

--- a/addons/WebBusPlugin/Demo/Demo.gd
+++ b/addons/WebBusPlugin/Demo/Demo.gd
@@ -64,8 +64,7 @@ func _on_get_yandex_leaderboard_info_pressed():
 	
 	
 func getting_leaderboard_info(info):
-	leaderboard_info = info 
-	print(leaderboard_info.name)
+	print(info)
 
 func _on_get_yandex_leaderboard_player_entry_pressed():
 	var name_leaderboard :String = $VBoxContainer/Yandex/HBoxContainer3/leaderboard.text

--- a/addons/WebBusPlugin/Demo/Demo.tscn
+++ b/addons/WebBusPlugin/Demo/Demo.tscn
@@ -105,6 +105,7 @@ text = "start_loading"
 [node name="Yandex" type="VBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
+size_flags_stretch_ratio = 1.55
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Yandex"]
 layout_mode = 2

--- a/addons/WebBusPlugin/WebBus.gd
+++ b/addons/WebBusPlugin/WebBus.gd
@@ -365,6 +365,16 @@ func _leaderboard_entries_recieved(info):
 	leaderboard_entries_recieved.emit(info[0])
 
 
+func get_server_time() -> int:
+	match platform:
+		Platform.YANDEX:
+			while not YandexSDK:
+				await _SDK_inited
+			return YandexSDK.serverTime()
+		_:
+			return 0
+
+
 #endregion
 
 #region Crazy Games

--- a/addons/WebBusPlugin/plugin.cfg
+++ b/addons/WebBusPlugin/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
-name="Wed Bus Plugin"
+name="WedBus"
 description="One plugin for yandex games and crazy games"
 author="Anatoly Kulagin"
-version="0.2.4"
+version="0.2.5"
 script="WedBusPlugin.gd"


### PR DESCRIPTION
Introduce a function to retrieve server time for the Yandex platform, update leaderboard-related functions for consistency, and enhance documentation. Additionally, update the plugin version and improve project organization by modifying the .gitignore file.